### PR TITLE
warcvalid.py: Report exceptions

### DIFF
--- a/hanzo/warcvalid.py
+++ b/hanzo/warcvalid.py
@@ -50,6 +50,7 @@ def main(argv):
                 
 
     except Exception as e:
+        print("Exception: %s"%(str(e)), file=sys.stderr)
         correct=False
     finally:
         if fh: fh.close()


### PR DESCRIPTION
warcvalid.py should report exceptions to stderr, as well as detected errors on reading records.

Previously, if a WARC file was broken and not reading effectively (perhaps due to gzip errors) then warcvalid would silently return -1 rather than printing errors. This gives a false sense of security to people using it from the command line.
