### PR TITLE
imports for python version 2.7.x

### DIFF
--- a/hanzo/warctools/s3.py
+++ b/hanzo/warctools/s3.py
@@ -1,9 +1,9 @@
 try:
     from urllib.parse import urlparse
 except ImportError:
-    import urlparse
+    from urlparse import urlparse
 
-from io import StringIO
+from io import BytesIO as StringIO
 
 try:
     from boto.s3.connection import S3Connection


### PR DESCRIPTION
Using python version 2.7.3 on Debian Wheezy.  Changes allowed S3 connection for commoncrawl dataset.  Also set anon=True for S3Connection.