### PR TITLE
Enable -o parameter in warc2warc tool

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ hanzo warc tools:
 
     warcvalid.py
         returns 0 if the arguments are all valid arc/warc files
-        non zero on error 
+        non zero on error
 
     warcdump.py - writes human readable summary of warcfiles:
         usage: python warcdump.py foo.warc foo.warc.gz
@@ -16,27 +16,31 @@ hanzo warc tools:
 
         assumes uncompressed warc on stdin if no args
 
-    warcfilter.py 
+    warcfilter.py
         python warcfilter.py pattern file file file
             searches all headers for regex pattern
         use -i to invert search
         use -U to constrain to url
         use -T to constrain to record type
         use -C to constrain to content-type
-            
+
         autodetects and stdin like warcdump
 
         prints out a warc format by default.
 
     warc2warc.py:
-        python warc2warc <input files>
+        python warc2warc [options] <input files>
 
-        autodetects compression on file
-        args, assumes uncompressed stdin if none
+        autodetects compression on file args,
+				assumes uncompressed stdin if none
 
         use -Z to write compressed output
 
-        i.e warc2warc -Z input > input.gz
+        i.e. warc2warc -Z input
+
+				use -o to specify output file
+
+				i.e. warc2warc input -o /path/to/output
 
         should ignore buggy records in input
 
@@ -52,7 +56,7 @@ hanzo warc tools:
 warccrap/mywarc.warc 1196018 request /images/slides/hanzo_markm__wwwoh.pdf <urn:uuid:fd1255a8-d07c-11df-b125-12313b0a18c6> application/http;msgtype=request 193
 warccrap/mywarc.warc 1196631 response http://www.hanzoarchives.com/images/slides/hanzo_markm__wwwoh.pdf <urn:uuid:fd2614f8-d07c-11df-b125-12313b0a18c6> application/http;msgtype=response 3279474
         not great, but a start
-                
+
 notes:
 
     arc2warc uses the conversion rules from the earlier arc2warc.c

--- a/hanzo/warc2warc.py
+++ b/hanzo/warc2warc.py
@@ -3,11 +3,8 @@
 
 from __future__ import print_function
 
+import sys
 import os
-import sys
-
-import sys
-import os.path
 
 from optparse import OptionParser
 
@@ -17,18 +14,23 @@ from .httptools import RequestMessage, ResponseMessage
 parser = OptionParser(usage="%prog [options] url (url ...)")
 
 parser.add_option("-o", "--output", dest="output",
-                       help="output warc file")
+                  help="output warc file")
 parser.add_option("-l", "--limit", dest="limit")
 parser.add_option("-I", "--input", dest="input_format", help="(ignored)")
-parser.add_option("-Z", "--gzip", dest="gzip", action="store_true", help="compress output, record by record")
-parser.add_option("-D", "--decode_http", dest="decode_http", action="store_true", help="decode http messages (strip chunks, gzip)")
+parser.add_option("-Z", "--gzip", dest="gzip", action="store_true",
+                  help="compress output, record by record")
+parser.add_option("-D", "--decode_http", dest="decode_http",
+                  action="store_true", help="decode http messages (strip chunks, gzip)")
 parser.add_option("-L", "--log-level", dest="log_level")
-parser.add_option("--wget-chunk-fix", dest="wget_workaround", action="store_true", help="skip transfer-encoding headers in http records, when decoding them (-D)")
+parser.add_option("--wget-chunk-fix", dest="wget_workaround", action="store_true",
+                  help="skip transfer-encoding headers in http records, when decoding them (-D)")
 
-parser.set_defaults(output_directory=None, limit=None, log_level="info", gzip=False, decode_http=False, wget_workaround=False)
+parser.set_defaults(output_directory=None, limit=None, log_level="info",
+                    gzip=False, decode_http=False, wget_workaround=False)
 
 
 WGET_IGNORE_HEADERS = ['Transfer-Encoding']
+
 
 def process(record, out, options):
     ignore_headers = WGET_IGNORE_HEADERS if options.wget_workaround else ()
@@ -39,8 +41,9 @@ def process(record, out, options):
             if content_type == ResponseMessage.CONTENT_TYPE:
                 # technically, a http request needs to know the request to be parsed
                 # because responses to head requests don't have a body.
-                # we assume we don't store 'head' responses, and plough on 
-                message = ResponseMessage(RequestMessage(), ignore_headers=ignore_headers)
+                # we assume we don't store 'head' responses, and plough on
+                message = ResponseMessage(
+                    RequestMessage(), ignore_headers=ignore_headers)
             if content_type == RequestMessage.CONTENT_TYPE:
                 message = RequestMessage(ignore_headers=ignore_headers)
 
@@ -53,20 +56,37 @@ def process(record, out, options):
                 else:
                     error = []
                     if leftover:
-                        error.append("%d bytes unparsed"%len(leftover))
+                        error.append("%d bytes unparsed" % len(leftover))
                     if not message.complete():
-                        error.append("incomplete message (at %s, %s)"%(message.mode, message.header.mode))
-                    print('errors decoding http in record', record.id, ",".join(error), file=sys.stderr)
+                        error.append("incomplete message (at %s, %s)" %
+                                     (message.mode, message.header.mode))
+                    print('errors decoding http in record',
+                          record.id, ",".join(error), file=sys.stderr)
 
     record.write_to(out, gzip=options.gzip)
+
 
 def main(argv):
     (options, input_files) = parser.parse_args(args=argv[1:])
 
-    try: # python3
-        out = sys.stdout.buffer
-    except AttributeError: # python2
-        out = sys.stdout
+    if options.output is None:
+        # output file is not specified,
+        # therefore write to stdout
+        try:
+            # python3
+            out = sys.stdout.buffer
+        except AttributeError:
+            # python2
+            out = sys.stdout
+    else:
+        # create path to output file if necessary
+        output_file = options.output
+        output_directory = os.path.dirname(options.output)
+        if output_directory != "":
+            os.makedirs(output_directory, exist_ok=True)
+        # open output file
+        output_descriptor = open(output_file, "wb")
+        out = output_descriptor
 
     if len(input_files) < 1:
         fh = WarcRecord.open_archive(file_handle=sys.stdin, gzip=None)
@@ -81,15 +101,13 @@ def main(argv):
 
             fh.close()
 
-
-
+    out.close()
     return 0
+
 
 def run():
     sys.exit(main(sys.argv))
 
 
-if __name__ == '__main__':  
+if __name__ == '__main__':
     run()
-
-

--- a/hanzo/warc2warc.py
+++ b/hanzo/warc2warc.py
@@ -11,6 +11,7 @@ from optparse import OptionParser
 from .warctools import WarcRecord, expand_files
 from .httptools import RequestMessage, ResponseMessage
 
+# TODO: The optparse module is deprecated. Maybe use argparse?
 parser = OptionParser(usage="%prog [options] url (url ...)")
 
 parser.add_option("-o", "--output", dest="output",
@@ -73,24 +74,30 @@ def main(argv):
         # output file is not specified,
         # therefore write to stdout
         try:
-            # python3
+            # Python 3
             out = sys.stdout.buffer
         except AttributeError:
-            # python2
+            # Python 2
             out = sys.stdout
     else:
-        # create path to output file if necessary
+        # output file is specified, therefore make
+        # sure that it exists correspondingly
         output_file = options.output
         output_directory = os.path.dirname(options.output)
         if output_directory != "":
-            os.makedirs(output_directory, exist_ok=True)
+            try:
+                # Python 3
+                os.makedirs(output_directory, exist_ok=True)
+            except TypeError:
+                # Python 2
+                if not os.path.exists(output_directory):
+                    os.makedirs(output_directory)
         # open output file
         output_descriptor = open(output_file, "wb")
         out = output_descriptor
 
     if len(input_files) < 1:
         fh = WarcRecord.open_archive(file_handle=sys.stdin, gzip=None)
-
         for record in fh:
             process(record, out, options)
     else:


### PR DESCRIPTION
Implemented -o parameter in warc2warc tool to specify output file. Runs with Python 2 and 3.

Updated README file correspondingly.