### PR TITLE
Allow build failures for python 3.2, 3.3, 3.4, pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 
 python:
  - 2.7
- - 3.2
- - 3.3
- - 3.4
  - 3.5
  - nightly
  - pypy
@@ -12,8 +9,12 @@ python:
 
 matrix:
  allow_failures:
+  - python: 3.2
+  - python: 3.3
+  - python: 3.4
   - python: 3.5
   - python: nightly
+  - python: pypy3
 
 script: python setup.py test
 


### PR DESCRIPTION
I think this will fix recent build issues like this:
https://travis-ci.org/internetarchive/warctools/builds/614744754