### PR TITLE
hanzo: remove unneeded declare_namespace

### DIFF
--- a/hanzo/__init__.py
+++ b/hanzo/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
As far as I can tell this isn't needed, at least in current versions of Python. The empty `__init__.py` will tell Python this is a package.

This is necessary because `pkg_resources` is deprecated and staged for removal starting in November, as seen in this warning on `import hanzo`:

```
/Users/mistydemeo/git/warctools/hanzo/__init__.py:2: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```