### PR TITLE
release: 5.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+__pycache__
+/warctools.egg-info

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Topic :: System :: Archiving',
     ],
@@ -35,5 +34,5 @@ setup(
     packages=['hanzo', 'hanzo.warctools', 'hanzo.httptools'],
     test_suite="nose.collector",
     tests_require=["nose"],
-    version='4.10.1.dev2',
+    version='4.11.0',
 )


### PR DESCRIPTION
Incorporates #33. Looks like there have been no other substantive changes since the last release.

I've dropped Python 2.7 from the supported platforms, since PEP 420 namespace packages doesn't appear to be supported on that release.