### PR TITLE
fix: typo in regex string

### DIFF
--- a/hanzo/httptools/messaging.py
+++ b/hanzo/httptools/messaging.py
@@ -505,7 +505,7 @@ class HTTPHeader(object):
             return self.content_length
 
 url_rx = re.compile(
-    b'(?P<scheme>https?)://(?P<authority>(?P<host>[^:/]+)(?::(?P<port>\d+))?)'
+    b'(?P<scheme>https?)://(?P<authority>(?P<host>[^:/]+)(?::(?P<port>\\d+))?)'
     b'(?P<path>.*)',
     re.I)
 


### PR DESCRIPTION
`\d` isn't a Python escape sequence. It currently raises a SyntaxWarning and parses to `\\d`, but it will be promoted to a syntax error in future versions of Python so we should fix this now.